### PR TITLE
Update to Minecraft 1.21.11 (Fabric Loader 0.18.1, Loom 1.14)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import java.util.concurrent.Callable
 
 plugins {
-    id 'fabric-loom' version '1.11-SNAPSHOT'
+    id 'fabric-loom' version '1.14-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,21 +3,21 @@ org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop/
-minecraft_version=1.21.7
-yarn_mappings=1.21.7+build.8
-loader_version=0.16.14
+minecraft_version=1.21.11
+yarn_mappings=1.21.11+build.4
+loader_version=0.18.1
 
 # Mod Properties
-mod_version=1.1.0+1.21.7
+mod_version=1.2.0+1.21.11
 maven_group=com.github.breadmoirai
 archives_base_name=one-click-anvil
 
 # Dependencies
 # check this on https://fabricmc.net/develop/
-fabric_version=0.129.0+1.21.7
+fabric_version=0.141.3+1.21.11
 
 # https://modrinth.com/mod/yacl/versions
-yacl_version=3.7.1+1.21.6-fabric
+yacl_version=3.8.2+1.21.11-fabric
 
 # https://modrinth.com/mod/modmenu/versions
-modmenu_version=15.0.0-beta.3
+modmenu_version=17.0.0-beta.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,12 +27,12 @@
     "one-click-anvil.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.15.7",
+    "fabricloader": ">=0.18.1",
     "fabric-key-binding-api-v1": "*",
-    "yet_another_config_lib_v3": ">=3.7.1+1.21.6-fabric"
+    "yet_another_config_lib_v3": ">=3.8.0"
   },
   "recommends": {
-    "minecraft": ">=1.21.6"
+    "minecraft": ">=1.21.11"
   },
   "accessWidener": "oneclickanvil.accesswidener",
   "custom": {

--- a/src/main/resources/one-click-anvil.mixins.json
+++ b/src/main/resources/one-click-anvil.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.github.breadmoirai.oneclickanvil.mixin",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
   ],
   "client": [

--- a/src/main/resources/oneclickanvil.accesswidener
+++ b/src/main/resources/oneclickanvil.accesswidener
@@ -1,6 +1,3 @@
 accessWidener v2 named
 
-accessible field net/minecraft/client/option/KeyBinding boundKey Lnet/minecraft/client/util/InputUtil$Key;
-
-accessible field net/minecraft/client/gui/screen/ingame/AnvilScreen player Lnet/minecraft/entity/player/PlayerEntity;
 accessible field net/minecraft/client/gui/screen/ingame/AnvilScreen nameField Lnet/minecraft/client/gui/widget/TextFieldWidget;


### PR DESCRIPTION
<html><body>
<!--StartFragment--><h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Description</h2>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">This PR updates OneClickAnvil from Minecraft 1.21.7 to 1.21.11 — the latest stable release of Minecraft: Java Edition.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">All dependencies have been updated to their latest compatible versions, and the access widener has been cleaned up to remove unused entries.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">No changes to the Java source code were necessary — the mod's Mixin target (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">AnvilScreen.onSlotUpdate</code>) and all other API usages remain compatible.</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Changes Summary</h2>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">gradle.properties</code></h3>
<div class="overflow-x-auto w-full px-2 mb-6">
Property | Old (1.21.7) | New (1.21.11)
-- | -- | --
minecraft_version | 1.21.7 | 1.21.11
yarn_mappings | 1.21.7+build.8 | 1.21.11+build.4
loader_version | 0.16.14 | 0.18.1
mod_version | 1.1.0+1.21.7 | 1.2.0+1.21.11
fabric_version | 0.129.0+1.21.7 | 0.141.3+1.21.11
yacl_version | 3.7.1+1.21.6-fabric | 3.8.2+1.21.11-fabric
modmenu_version | 15.0.0-beta.3 | 17.0.0-beta.2

</div>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">build.gradle</code></h3>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2">Fabric Loom: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">1.11-SNAPSHOT</code> → <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">1.14-SNAPSHOT</code></li>
</ul>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">gradle/wrapper/gradle-wrapper.properties</code></h3>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2">Gradle: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">9.0.0</code> → <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">9.2.0</code> (required by Loom 1.14)</li>
</ul>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/main/resources/one-click-anvil.mixins.json</code></h3>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">compatibilityLevel</code>: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">JAVA_17</code> → <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">JAVA_21</code></li>
</ul>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/main/resources/fabric.mod.json</code></h3>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">fabricloader</code> minimum: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">&gt;=0.15.7</code> → <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">&gt;=0.18.1</code></li>
<li class="whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">yet_another_config_lib_v3</code> minimum: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">&gt;=3.7.1+1.21.6-fabric</code> → <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">&gt;=3.8.0</code></li>
<li class="whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">minecraft</code> recommendation: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">&gt;=1.21.6</code> → <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">&gt;=1.21.11</code></li>
</ul>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/main/resources/oneclickanvil.accesswidener</code></h3>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Removed two unused access widener entries:</p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">accessible field net/minecraft/client/option/KeyBinding boundKey</code> — not referenced in the mod's source code</li>
<li class="whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">accessible field net/minecraft/client/gui/screen/ingame/AnvilScreen player</code> — not referenced in the mod's source code</li>
</ul>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Retained:</p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">accessible field net/minecraft/client/gui/screen/ingame/AnvilScreen nameField</code> — still required by <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">OneClickAnvilClient.java</code></li>
</ul>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">Java Source Code</h3>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">No changes. All source files remain identical to the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">main</code> branch.</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Testing</h2>
<ul class="contains-task-list">
<li class="task-list-item"><input disabled="" type="checkbox"> Mod compiles with <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">./gradlew build</code></li>
<li class="task-list-item"><input disabled="" type="checkbox"> Mod loads correctly in Minecraft 1.21.11 with Fabric Loader 0.18.1</li>
<li class="task-list-item"><input disabled="" type="checkbox"> Anvil auto-rename functionality works as expected</li>
<li class="task-list-item"><input disabled="" type="checkbox"> ModMenu config screen opens and saves correctly</li>
<li class="task-list-item"><input disabled="" type="checkbox"> YACL config options render properly</li>
</ul>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Notes</h2>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Minecraft 1.21.11 is the last obfuscated version. The next release (26.1 "Tiny Takeover") will be unobfuscated, and Yarn mappings will no longer be updated. A future PR will be needed to migrate from Yarn to Mojang Mappings when targeting 26.1+.</p><!--EndFragment-->
</body>
</html>